### PR TITLE
Update repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # com.valvesoftware.Steam.Utility.steamtinkerlaunch
 
-Flatpak for [SteamTinkerLaunch](https://github.com/frostworx/steamtinkerlaunch/)
+Flatpak for [SteamTinkerLaunch](https://github.com/sonic2kk/steamtinkerlaunch/)
 
 ## Install
 
 `flatpak install com.valvesoftware.Steam.Utility.steamtinkerlaunch`
 
 ## Usage
-[Read the SteamTinkerLaunch Flatpak Wiki page](https://github.com/frostworx/steamtinkerlaunch/wiki/Steam-Flatpak)
+[Read the SteamTinkerLaunch Flatpak Wiki page](https://github.com/sonic2kk/steamtinkerlaunch/wiki/Steam-Flatpak)
 
 ## Uninstall
 

--- a/com.valvesoftware.Steam.Utility.steamtinkerlaunch.metainfo.xml
+++ b/com.valvesoftware.Steam.Utility.steamtinkerlaunch.metainfo.xml
@@ -3,7 +3,7 @@
   <id>com.valvesoftware.Steam.Utility.steamtinkerlaunch</id>
   <extends>com.valvesoftware.Steam</extends>
   <name>SteamTinkerLaunch</name>
-  <developer_name>frostworx</developer_name>
+  <developer_name>sonic2kk</developer_name>
   <summary>Linux wrapper tool for use with the Flatpak Steam client allowing use of custom launch options and 3rd party applications</summary>
   <description>
     <p>Steam Tinker Launch is a Linux wrapper tool for use with the Steam client which allows customising start tools and options for games quickly on the fly.</p>
@@ -12,15 +12,15 @@
   <categories>
     <category>Game</category>
   </categories>
-  <icon type="remote" height="64" width="64">https://raw.githubusercontent.com/frostworx/steamtinkerlaunch/master/misc/steamtinkerlaunch.svg</icon>
-  <icon type="remote" height="128" width="128">https://raw.githubusercontent.com/frostworx/steamtinkerlaunch/master/misc/steamtinkerlaunch.svg</icon>
-  <url type="homepage">https://github.com/frostworx/steamtinkerlaunch</url>
-  <url type="help">https://github.com/frostworx/steamtinkerlaunch/wiki</url>
-  <url type="bugtracker">https://github.com/frostworx/steamtinkerlaunch/issues</url>
+  <icon type="remote" height="64" width="64">https://raw.githubusercontent.com/sonic2kk/steamtinkerlaunch/master/misc/steamtinkerlaunch.svg</icon>
+  <icon type="remote" height="128" width="128">https://raw.githubusercontent.com/sonic2kk/steamtinkerlaunch/master/misc/steamtinkerlaunch.svg</icon>
+  <url type="homepage">https://github.com/sonic2kk/steamtinkerlaunch</url>
+  <url type="help">https://github.com/sonic2kk/steamtinkerlaunch/wiki</url>
+  <url type="bugtracker">https://github.com/sonic2kk/steamtinkerlaunch/issues</url>
   <screenshots>
     <screenshot type="default">
       <caption>Example of a game's main menu window</caption>
-      <image>https://github.com/frostworx/repo-assets/raw/master/pics/Main-Menu.jpg</image>
+      <image>https://user-images.githubusercontent.com/7917345/186237765-8803c246-a025-413b-be8c-f2c13243291d.png</image>
     </screenshot>
   </screenshots>
   <releases>

--- a/com.valvesoftware.Steam.Utility.steamtinkerlaunch.yml
+++ b/com.valvesoftware.Steam.Utility.steamtinkerlaunch.yml
@@ -46,7 +46,7 @@ modules:
       - install -Dm644 -t ${FLATPAK_DEST} toolmanifest.vdf
     sources:
       - type: git
-        url: https://github.com/frostworx/steamtinkerlaunch/
+        url: https://github.com/sonic2kk/steamtinkerlaunch/
         commit: 935380f4e8284fb17ab5333330fca71439ac9b11
       - type: file
         path: SteamTinkerLaunch.vdf


### PR DESCRIPTION
Hey there!

Today, Frostworx [stepped down](https://github.com/sonic2kk/steamtinkerlaunch/issues/632) as maintainer of SteamTinkerLaunch and I have now taken over as project lead.

I updated the URLs to point to [`sonic2kk/steamtinkerlaunch`](https://github.com/sonic2kk/steamtinkerlaunch). If you go to [`frostworx/steamtinkerlaunch`](https://github.com/frostworx/steamtinkerlaunch) it will redirect you, at least for now, but I figured it was a good idea to update the URLs to point to the "correct" URL.

I also updated the screenshot to point to the same one on the Readme. It's from v11.0 and not v11.11, but there is no change to the main menu.

Please let me know if I missed anywhere or did anything wrong. Thank you!